### PR TITLE
pydasm: remove leak of malloced memory of insn.ptr

### DIFF
--- a/pydasm/pydasm.c
+++ b/pydasm/pydasm.c
@@ -582,6 +582,7 @@ PyObject *pydasm_get_mnemonic_string(PyObject *self, PyObject *args)
     get_mnemonic_string(&insn, format, data, INSTRUCTION_STR_BUFFER_LENGTH);
       
     pStr = PyString_FromStringAndSize(data, strlen(data));
+    free(insn.ptr);
     free(data);
     
     return pStr;
@@ -651,6 +652,7 @@ PyObject *pydasm_get_operand_string(PyObject *self, PyObject *args)
     }
     
     pStr = PyString_FromStringAndSize(data, strlen(data));
+    free(insn.ptr);
     free(data);
     
     return pStr;


### PR DESCRIPTION
Hi,

I have an application that uses pydasm heavily, and I noticed memory leaking. tcmalloc pointed me to memory leaking from fill_inst_structure. That is in the call chain of pydasm_get_instruction_string, pydasm_get_mnemonic_string and pydasm_get_operand_string. pydasm_get_instruction_string already freed insn.ptr before leaving, but the other two did not.

The patch doesn't handle the exception cases, but it has helped my application to keep using more constant memory.